### PR TITLE
feat: livewire toaster

### DIFF
--- a/app/Http/Controllers/Vaults/VaultController.php
+++ b/app/Http/Controllers/Vaults/VaultController.php
@@ -46,7 +46,8 @@ class VaultController extends Controller
             description: $validated['description'],
         ))->execute();
 
-        return redirect()->route('vaults.show', $vault);
+        return redirect()->route('vaults.show', $vault)
+            ->success(trans('The vault has been created'));
     }
 
     public function show(Request $request): View
@@ -67,6 +68,7 @@ class VaultController extends Controller
 
         $request->session()->flash('status', __('The vault has been deleted'));
 
-        return redirect()->route('vaults.index');
+        return redirect()->route('vaults.index')
+            ->success(trans('The vault has been deleted'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "laravel/tinker": "^2.9",
     "livewire/livewire": "^3.5",
     "mallardduck/blade-lucide-icons": "^1.23",
+    "masmerise/livewire-toaster": "^2.3",
     "pragmarx/google2fa": "^8.0",
     "stichoza/google-translate-php": "^5.1"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3ca56282eb26a782a10e23b425d6269",
+    "content-hash": "23671032e801fa2b92b8247ac1577b5b",
     "packages": [
         {
             "name": "amirami/localizator",
@@ -2433,6 +2433,77 @@
                 "source": "https://github.com/mallardduck/blade-lucide-icons/tree/1.23.0"
             },
             "time": "2024-07-22T15:40:39+00:00"
+        },
+        {
+            "name": "masmerise/livewire-toaster",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/masmerise/livewire-toaster.git",
+                "reference": "238f92452f30efb33db763dfeba9300616c92ed3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/masmerise/livewire-toaster/zipball/238f92452f30efb33db763dfeba9300616c92ed3",
+                "reference": "238f92452f30efb33db763dfeba9300616c92ed3",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.0",
+                "livewire/livewire": "^3.0",
+                "php": "~8.2|~8.3"
+            },
+            "conflict": {
+                "stevebauman/unfinalize": "*"
+            },
+            "require-dev": {
+                "dive-be/php-crowbar": "^1.0",
+                "larastan/larastan": "^2.0",
+                "laravel/pint": "^1.0",
+                "orchestra/testbench": "^9.0",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Toaster": "Masmerise\\Toaster\\Toaster"
+                    },
+                    "providers": [
+                        "Masmerise\\Toaster\\ToasterServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masmerise\\Toaster\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Muhammed Sari",
+                    "email": "support@muhammedsari.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Beautiful toast notifications for Laravel / Livewire.",
+            "homepage": "https://github.com/masmerise/livewire-toaster",
+            "keywords": [
+                "alert",
+                "laravel",
+                "livewire",
+                "toast",
+                "toaster"
+            ],
+            "support": {
+                "issues": "https://github.com/masmerise/livewire-toaster/issues",
+                "source": "https://github.com/masmerise/livewire-toaster/tree/2.3.1"
+            },
+            "time": "2024-07-21T10:39:11+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/config/toaster.php
+++ b/config/toaster.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+return [
+
+    /**
+     * Add an additional second for every 100th word of the toast messages.
+     *
+     * Supported: true | false
+     */
+    'accessibility' => true,
+
+    /**
+     * The vertical alignment of the toast container.
+     *
+     * Supported: "bottom", "middle" or "top"
+     */
+    'alignment' => 'bottom',
+
+    /**
+     * Allow users to close toast messages prematurely.
+     *
+     * Supported: true | false
+     */
+    'closeable' => true,
+
+    /**
+     * The on-screen duration of each toast.
+     *
+     * Minimum: 3000 (in milliseconds)
+     */
+    'duration' => 3000,
+
+    /**
+     * The horizontal position of each toast.
+     *
+     * Supported: "center", "left" or "right"
+     */
+    'position' => 'right',
+
+    /**
+     * Whether messages passed as translation keys should be translated automatically.
+     *
+     * Supported: true | false
+     */
+    'translate' => true,
+];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
 import './bootstrap';
+import '../../vendor/masmerise/livewire-toaster/resources/js';
 
 // import Alpine from 'alpinejs';
 // import htmx from 'htmx.org';

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -39,15 +39,7 @@
       </main>
 
       <!-- toaster -->
-      @if (session('status'))
-        <div x-data="{ show: true }" x-show="show" x-init="setTimeout(() => (show = false), 3000)" class="absolute bottom-12 right-10 mx-auto max-w-xl px-2 pt-6 sm:px-6 lg:px-8">
-          <div class="flex items-center overflow-hidden rounded border border-green-600 bg-white px-5 py-2.5 shadow-sm shadow-gray-400 dark:bg-gray-800">
-            <div class="mr-2 bg-green-100 px-2 py-2"></div>
-
-            <p>{{ session('status') }}</p>
-          </div>
-        </div>
-      @endif
+      <x-toaster-hub />
     </div>
 
     @livewireScripts

--- a/resources/views/vaults/contacts/show.blade.php
+++ b/resources/views/vaults/contacts/show.blade.php
@@ -163,7 +163,7 @@
                 </div>
 
                 <div class="button -left-6 flex cursor-pointer items-center rounded border bg-white text-sm">
-                  <x-heroicon-o-plus class="h-4 w-4" />
+                  {{-- <x-heroicon-o-plus class="h-4 w-4" /> --}}
                 </div>
               </div>
             </div>

--- a/resources/views/vaults/show.blade.php
+++ b/resources/views/vaults/show.blade.php
@@ -1,1 +1,1 @@
-<x-app-layout :vault="$vault">sdfs</x-app-layout>
+<x-app-layout :vault="$vault">energie; {{ session()->get('success') }}</x-app-layout>

--- a/tests/Feature/Controllers/Vaults/VaultControllerTest.php
+++ b/tests/Feature/Controllers/Vaults/VaultControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Controllers\Vaults;
 use App\Models\User;
 use App\Models\Vault;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Masmerise\Toaster\Toaster;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -57,6 +58,7 @@ class VaultControllerTest extends TestCase
     #[Test]
     public function a_user_can_create_a_vault(): void
     {
+        Toaster::fake();
         $user = User::factory()->create();
 
         $this->actingAs($user)
@@ -65,6 +67,8 @@ class VaultControllerTest extends TestCase
                 'description' => 'this is the description',
             ])
             ->assertRedirectToRoute('vaults.show', ['vault' => Vault::first()]);
+
+        Toaster::assertDispatched('The vault has been created');
     }
 
     #[Test]
@@ -93,11 +97,14 @@ class VaultControllerTest extends TestCase
     #[Test]
     public function a_user_can_delete_a_vault(): void
     {
+        Toaster::fake();
         $user = User::factory()->create();
         $vault = $this->createVault($user);
 
         $this->actingAs($user)
             ->delete('/vaults/'.$vault->id)
             ->assertRedirectToRoute('vaults.index');
+
+        Toaster::assertDispatched('The vault has been deleted');
     }
 }


### PR DESCRIPTION
This pull request introduces the integration of the `livewire-toaster` package to enhance user notifications and updates related configurations, views, and tests accordingly. The most important changes include adding success messages to redirect responses, updating the `composer.json` file to include the new package, and modifying views to utilize the toaster component.

### Integration of `livewire-toaster` package:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R20): Added the `masmerise/livewire-toaster` package to dependencies.
* [`resources/js/app.js`](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdR2): Imported the `livewire-toaster` JavaScript resources.
* [`config/toaster.php`](diffhunk://#diff-01a07f71f3239df3d85536b7710def2138628b1391f5ff1c9ef11c7ba4276ae0R1-R46): Created a configuration file for the toaster settings.

### Updates to user notifications:

* [`app/Http/Controllers/Vaults/VaultController.php`](diffhunk://#diff-7c4ae74b735e27132f74e9654cc933be112c1adf9d879c79e6e0b0611b0b9930L49-R50): Added success messages to the redirect responses in the `store` and `destroy` methods. [[1]](diffhunk://#diff-7c4ae74b735e27132f74e9654cc933be112c1adf9d879c79e6e0b0611b0b9930L49-R50) [[2]](diffhunk://#diff-7c4ae74b735e27132f74e9654cc933be112c1adf9d879c79e6e0b0611b0b9930L70-R72)
* [`resources/views/layouts/app.blade.php`](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L42-R42): Replaced the manual toast message display with the `x-toaster-hub` component.

### Test updates:

* [`tests/Feature/Controllers/Vaults/VaultControllerTest.php`](diffhunk://#diff-3d9fe821b163521d4e0f642328cd0e467e0fb280a0a3bff114b86897333f1044R8): Added `Toaster::fake()` and `Toaster::assertDispatched()` to relevant tests to verify that toast messages are dispatched correctly. [[1]](diffhunk://#diff-3d9fe821b163521d4e0f642328cd0e467e0fb280a0a3bff114b86897333f1044R8) [[2]](diffhunk://#diff-3d9fe821b163521d4e0f642328cd0e467e0fb280a0a3bff114b86897333f1044R61) [[3]](diffhunk://#diff-3d9fe821b163521d4e0f642328cd0e467e0fb280a0a3bff114b86897333f1044R70-R71) [[4]](diffhunk://#diff-3d9fe821b163521d4e0f642328cd0e467e0fb280a0a3bff114b86897333f1044R100-R108)