### PR TITLE
feat: add default journal template to account setup

### DIFF
--- a/.cursor/prompts/create-commit/system.md
+++ b/.cursor/prompts/create-commit/system.md
@@ -42,7 +42,7 @@ You are an expert Git commit message generator, specializing in creating concise
 2. Commit with body:
 
    ```bash
-   git commit -m "feat(auth): implement two-factor authentication'
+   git commit -m "feat: implement two-factor authentication'
 
    - add sms and email options for 2fa
    - update user model to support 2fa preferences

--- a/app/Jobs/SetupAccount.php
+++ b/app/Jobs/SetupAccount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Models\User;
+use App\Services\CreateJournalTemplate;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -31,6 +32,7 @@ class SetupAccount implements ShouldQueue
     {
         $this->createGenders();
         $this->createTaskCategories();
+        $this->createJournalTemplate();
     }
 
     private function createGenders(): void
@@ -106,5 +108,33 @@ class SetupAccount implements ShouldQueue
                 'updated_at' => null,
             ],
         ]);
+    }
+
+    private function createJournalTemplate(): void
+    {
+        $template = <<<'YAML'
+template:
+  name: "Daily Reflection"
+  columns:
+    - name: "Morning"
+      questions:
+        - name: "Sleep quality"
+          answers:
+            type: "range"
+            range: [1, 5]
+            comment_allowed: true
+    - name: "Afternoon"
+      questions:
+        - name: "Productivity"
+          answers:
+            type: "choice"
+            options: ["High", "Medium", "Low"]
+            comment_allowed: false
+YAML;
+        (new CreateJournalTemplate(
+            user: $this->user,
+            name: 'My first template',
+            content: $template,
+        ))->execute();
     }
 }

--- a/tests/Unit/Jobs/SetupAccountTest.php
+++ b/tests/Unit/Jobs/SetupAccountTest.php
@@ -28,5 +28,9 @@ class SetupAccountTest extends TestCase
             6,
             DB::table('task_categories')->count()
         );
+        $this->assertEquals(
+            1,
+            DB::table('journal_templates')->count()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements a default journal template system during account setup, providing users with a pre-configured daily reflection template that includes structured sections for morning and afternoon entries.

## Changes

- Add createJournalTemplate method to SetupAccount job