### PR TITLE
refactor: streamline select statement in people list cache

### DIFF
--- a/app/Cache/PeopleListCache.php
+++ b/app/Cache/PeopleListCache.php
@@ -36,6 +36,16 @@ final class PeopleListCache extends CacheHelper
     {
         return Person::where('account_id', $this->identifier)
             ->where('is_listed', true)
+            ->select(
+                'id',
+                'first_name',
+                'last_name',
+                'maiden_name',
+                'nickname',
+                'slug',
+                'profile_photo_path',
+                'color'
+            )
             ->get()
             ->map(fn (Person $person): array => [
                 'id' => $person->id,


### PR DESCRIPTION
This pull request includes a change to the `generate` method in the `PeopleListCache` class to optimize the data retrieval process. The most important change is the addition of specific columns to the `select` clause to limit the data fetched from the database.

Optimization of data retrieval:

* [`app/Cache/PeopleListCache.php`](diffhunk://#diff-5dac6f0ea815834a02bd6d27d5997aea52058079fd0f751ed3b3ffecf216b887R39-R48): Modified the `generate` method to include a `select` clause specifying the columns 'id', 'first_name', 'last_name', 'maiden_name', 'nickname', 'slug', 'profile_photo_path', and 'color' to optimize the query.