### PR TITLE
chore: remove pre-commit hook for prettier and lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,0 @@
-npx prettier --write resources/
-npm run lint-staged


### PR DESCRIPTION
Removing the pre-commit hook for prettier and lint-staged streamlines the commit process by eliminating automatic formatting and linting checks. This change allows developers to have more control over when to apply these tools, potentially speeding up the commit workflow.

- Removed the pre-commit hook for prettier.

- Removed the pre-commit hook for lint-staged.