### PR TITLE
feat: add csrf token automatic refresh

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -12,3 +12,14 @@ Alpine.plugin(ajax);
 Alpine.plugin(intersect);
 
 Alpine.start();
+
+function refreshCsrfToken() {
+  fetch('/refresh-csrf')
+    .then(response => response.json())
+    .then(data => {
+      document.querySelector('meta[name="csrf-token"]').setAttribute('content', data.csrfToken);
+    });
+}
+
+// Refresh CSRF token every 10 minutes (600,000 milliseconds)
+setInterval(refreshCsrfToken, 600000);

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,6 +88,10 @@ Route::middleware(['marketing', 'marketing.page'])->group(function (): void {
 
 Route::get('/invitations/{user}/accept', [AdministrationController::class, 'accept'])->name('invitation.accept');
 
+Route::get('/refresh-csrf', function () {
+    return response()->json(['csrfToken' => csrf_token()]);
+});
+
 Route::middleware(['auth:sanctum', 'verified', 'throttle:60,1'])->group(function (): void {
     // marketing
     Route::post('/vote/{page}/helpful', [MarketingVoteHelpfulController::class, 'update'])->name('marketing.vote-helpful');


### PR DESCRIPTION
Implement an automatic refresh for the CSRF token every 10 minutes to enhance security and ensure that the token remains valid during user sessions. This change reduces the risk of CSRF attacks by keeping the token up-to-date without requiring user intervention.

- Added a function to fetch and update the CSRF token.

- Set an interval to refresh the CSRF token every 10 minutes.

- Created a new route to return the current CSRF token in JSON format.