### PR TITLE
fix: fix changelog generation

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -31,5 +31,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: ${{ github.event.release.target_commitish }}
-          commit_message: chore: update changelog
+          commit_message: 'chore: update changelog'
           file_pattern: CHANGELOG.md


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/update-changelog.yaml` file. The change updates the `commit_message` value to be enclosed in single quotes.