### PR TITLE
fix: add priority level to scheduled jobs in console

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -13,6 +13,6 @@ Artisan::command('inspire', function (): void {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
 
-Schedule::job(new CountDailyUsers())->dailyAt('00:20');
-Schedule::job(new ProcessReminders())->dailyAt('00:00');
-Schedule::job(new DeleteInactiveAccounts())->dailyAt('00:30');
+Schedule::job(new CountDailyUsers(), 'low')->dailyAt('00:20');
+Schedule::job(new ProcessReminders(), 'low')->dailyAt('00:00');
+Schedule::job(new DeleteInactiveAccounts(), 'low')->dailyAt('00:30');


### PR DESCRIPTION
Add a priority level to scheduled jobs to enhance job management and execution order. This change allows for better control over job scheduling, ensuring that more critical tasks can be prioritized as needed.

- Added 'low' priority level to CountDailyUsers, ProcessReminders, and DeleteInactiveAccounts jobs.