### PR TITLE
refactor: add lazy loading to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/djaiss/peopleos">
-   <img src="docs/github/background-github.png" alt="Logo">
+   <img src="docs/github/background-github.png" alt="Logo" loading="lazy">
   </a>
 
   <p align="center">

--- a/resources/views/administration/partials/avatar.blade.php
+++ b/resources/views/administration/partials/avatar.blade.php
@@ -27,7 +27,7 @@
       <!-- Front face -->
       <div x-ref="frontFace" class="absolute w-full border border-gray-200 bg-white [backface-visibility:hidden] sm:rounded-lg">
         <div class="grid grid-cols-3 items-center rounded-t-lg p-3 last:rounded-b-lg hover:bg-blue-50">
-          <img width="58" height="58" class="col-span-2 h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ auth()->user()->getAvatar(64) }}" srcset="{{ auth()->user()->getAvatar(64) }} 1x, {{ auth()->user()->getAvatar(128) }} 2x" alt="{{ auth()->user()->name }}" wire:key="avatar-{{ auth()->user()->id }}" />
+          <img width="58" height="58" class="col-span-2 h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ auth()->user()->getAvatar(64) }}" srcset="{{ auth()->user()->getAvatar(64) }} 1x, {{ auth()->user()->getAvatar(128) }} 2x" alt="{{ auth()->user()->name }}" loading="lazy" />
           <div class="justify-self-end">
             <x-button.invisible @click="isFlipped = true" class="text-sm">
               {{ __('Upload a new photo') }}

--- a/resources/views/components/marketing/handbook-stats.blade.php
+++ b/resources/views/components/marketing/handbook-stats.blade.php
@@ -9,7 +9,7 @@
         <p class="text-primary/50 m-0 line-clamp-1 text-sm leading-tight text-gray-400">Main maintainer</p>
       </div>
       <div class="flex-shrink-0 px-4 py-2">
-        <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis@2x.webp') }} 2x" alt="Regis" class="h-12 w-12 rounded-full" />
+        <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis@2x.webp') }} 2x" alt="Regis" class="h-12 w-12 rounded-full" loading="lazy" />
       </div>
     </a>
   </div>

--- a/resources/views/components/marketing/marketing-page-widget.blade.php
+++ b/resources/views/components/marketing/marketing-page-widget.blade.php
@@ -31,7 +31,7 @@
 
       @if (! Auth::check())
         <div x-cloak x-show="showTooltip" x-transition:enter="transition duration-200 ease-out" x-transition:enter-start="translate-y-1 opacity-0" x-transition:enter-end="translate-y-0 opacity-100" x-transition:leave="transition duration-150 ease-in" x-transition:leave-start="translate-y-0 opacity-100" x-transition:leave-end="translate-y-1 opacity-0" class="absolute top-full left-1/2 z-50 mt-0 flex w-96 -translate-x-1/2 items-center gap-x-3 rounded-lg bg-white p-4 shadow-lg ring-1 ring-black/5">
-          <img src="{{ asset('marketing/taylor.webp') }}" srcset="{{ asset('marketing/taylor@2x.webp') }} 2x" alt="Taylor Swift being happy" height="80" width="80" />
+          <img src="{{ asset('marketing/taylor.webp') }}" srcset="{{ asset('marketing/taylor@2x.webp') }} 2x" alt="Taylor Swift being happy" height="80" width="80" loading="lazy" />
           <div class="flex flex-col">
             <p class="text-sm text-gray-600">Please login to vote.</p>
             <p class="text-sm text-gray-600">It's free and will help us improve the page.</p>
@@ -45,7 +45,7 @@
   <!-- thanks message -->
   @if (session('hasVoted'))
     <div id="thanks" class="flex items-center justify-center gap-x-8 border-b border-gray-200 p-4 pb-4">
-      <img src="{{ asset('marketing/obama.webp') }}" srcset="{{ asset('marketing/obama@2x.webp') }} 2x" alt="Obama agreeing with you" height="100" width="100" />
+      <img src="{{ asset('marketing/obama.webp') }}" srcset="{{ asset('marketing/obama@2x.webp') }} 2x" alt="Obama agreeing with you" height="100" width="100" loading="lazy" />
 
       <div class="flex flex-col gap-y-2">
         <p class="font-semibold">{{ __('Thanks for your feedback!') }}</p>

--- a/resources/views/marketing/index.blade.php
+++ b/resources/views/marketing/index.blade.php
@@ -38,7 +38,7 @@
 
         <!-- Right side - Image -->
         <div class="relative">
-          <img src="{{ asset('marketing/homepage.png') }}" alt="PeopleOS Screenshot" class="rounded-xl shadow-xl ring-1 ring-gray-400/10" />
+          <img src="{{ asset('marketing/homepage.png') }}" alt="PeopleOS Screenshot" class="rounded-xl shadow-xl ring-1 ring-gray-400/10" loading="lazy" />
           <!-- Optional decorative elements -->
           <div class="absolute -z-10 hidden lg:block">
             <div class="absolute -top-16 -right-16 h-72 w-72 rounded-full bg-blue-50 opacity-70 mix-blend-multiply blur-2xl"></div>
@@ -123,7 +123,7 @@
         </div>
         <div class="flex flex-col items-center lg:col-span-1 lg:items-start" x-data="{ isRotating: false }">
           <div class="relative">
-            <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis.webp') }} 1x, {{ asset('marketing/regis@2x.webp') }} 2x" alt="Monica" class="mb-3 w-40 rounded-lg transition-all duration-[2000ms] ease-[cubic-bezier(0.34,1.56,0.64,1)] hover:scale-110 hover:rotate-[360deg] lg:rotate-4" @mouseenter="isRotating = true" @mouseleave="isRotating = false" @transitionend="isRotating = false" />
+            <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis.webp') }} 1x, {{ asset('marketing/regis@2x.webp') }} 2x" alt="Monica" class="mb-3 w-40 rounded-lg transition-all duration-[2000ms] ease-[cubic-bezier(0.34,1.56,0.64,1)] hover:scale-110 hover:rotate-[360deg] lg:rotate-4" @mouseenter="isRotating = true" @mouseleave="isRotating = false" @transitionend="isRotating = false" loading="lazy" />
 
             <!-- Tooltip -->
             <div x-show="isRotating" x-transition.opacity class="bg-opacity-75 absolute top-1/2 left-full ml-3 -translate-y-1/2 rounded-lg bg-black px-3 py-2 text-sm whitespace-nowrap text-white">Please stooooop this! 😵‍💫</div>
@@ -262,7 +262,7 @@
         <div class="grid grid-cols-1 gap-x-8 gap-y-16 lg:grid-cols-4">
           <div class="rotate-2 rounded-lg border border-gray-200 bg-white p-4">
             <div class="mb-2 flex items-center justify-center">
-              <img src="{{ asset('marketing/good_memory.webp') }}" srcset="{{ asset('marketing/good_memory.webp') }} 1x, {{ asset('marketing/good_memory@2x.webp') }} 2x" alt="Good memory" width="167" height="250" />
+              <img src="{{ asset('marketing/good_memory.webp') }}" srcset="{{ asset('marketing/good_memory.webp') }} 1x, {{ asset('marketing/good_memory@2x.webp') }} 2x" alt="Good memory" width="167" height="250" loading="lazy" />
             </div>
             <p class="mb-3 text-xl">You have a good memory</p>
             <p class="text-sm">If you can remember everything about everyone you know, you probably don't need this tool.</p>
@@ -270,7 +270,7 @@
 
           <div class="-rotate-1 rounded-lg border border-gray-200 bg-white p-4">
             <div class="mb-2 flex items-center justify-center">
-              <img src="{{ asset('marketing/recurring.webp') }}" srcset="{{ asset('marketing/recurring.webp') }} 1x, {{ asset('marketing/recurring@2x.webp') }} 2x" alt="Expensive subscriptions" width="167" height="250" />
+              <img src="{{ asset('marketing/recurring.webp') }}" srcset="{{ asset('marketing/recurring.webp') }} 1x, {{ asset('marketing/recurring@2x.webp') }} 2x" alt="Expensive subscriptions" width="167" height="250" loading="lazy" />
             </div>
             <p class="mb-3 text-xl">You like expensive, reccuring subscriptions</p>
             <p class="text-sm">We offer the a one-time payment for the software. No subscriptions, no hidden fees.</p>
@@ -278,7 +278,7 @@
 
           <div class="-rotate-1 rounded-lg border border-gray-200 bg-white p-4">
             <div class="mb-2 flex items-center justify-center">
-              <img src="{{ asset('marketing/ads.webp') }}" srcset="{{ asset('marketing/ads.webp') }} 1x, {{ asset('marketing/ads@2x.webp') }} 2x" alt="Ads" width="167" height="250" />
+              <img src="{{ asset('marketing/ads.webp') }}" srcset="{{ asset('marketing/ads.webp') }} 1x, {{ asset('marketing/ads@2x.webp') }} 2x" alt="Ads" width="167" height="250" loading="lazy" />
             </div>
             <p class="mb-3 text-xl">You like being tracked for ads purposes</p>
             <p class="text-sm">We do track users to serve ads, and don't profile our users. We hate ads as much as you do.</p>
@@ -286,7 +286,7 @@
 
           <div class="rotate-2 rounded-lg border border-gray-200 bg-white p-4">
             <div class="mb-2 flex items-center justify-center">
-              <img src="{{ asset('marketing/prison.webp') }}" srcset="{{ asset('marketing/prison.webp') }} 1x, {{ asset('marketing/prison@2x.webp') }} 2x" alt="Prison" width="167" height="250" />
+              <img src="{{ asset('marketing/prison.webp') }}" srcset="{{ asset('marketing/prison.webp') }} 1x, {{ asset('marketing/prison@2x.webp') }} 2x" alt="Prison" width="167" height="250" loading="lazy" />
             </div>
             <p class="mb-3 text-xl">You like being locked in</p>
             <p class="text-sm">We strongly advocate that you don't use our hosted version, and that you self-host the software on a server of your own.</p>

--- a/resources/views/marketing/partials/footer.blade.php
+++ b/resources/views/marketing/partials/footer.blade.php
@@ -104,7 +104,7 @@
           <div class="flex items-center gap-x-4 sm:gap-x-2">
             <a href="{{ route('marketing.index') }}" class="group flex items-center gap-x-2 transition-transform ease-in-out">
               <div class="flex h-7 w-7 items-center justify-center transition-all duration-400 group-hover:-translate-y-0.5 group-hover:-rotate-3">
-                <img src="{{ asset('marketing/logo.webp') }}" alt="PeopleOS logo" width="25" height="25" srcset="{{ asset('marketing/logo.webp') }} 1x, {{ asset('marketing/logo@2x.webp') }} 2x" />
+                <img src="{{ asset('marketing/logo.webp') }}" alt="PeopleOS logo" width="25" height="25" srcset="{{ asset('marketing/logo.webp') }} 1x, {{ asset('marketing/logo@2x.webp') }} 2x" loading="lazy" />
               </div>
             </a>
             <p class="text-xs text-gray-600">&copy; {{ date('Y') }} {{ config('app.name') }}. {{ __('All rights reserved. Actually, our trademark is not registered, but we probably should write that to do like the big boys.') }}</p>

--- a/resources/views/marketing/pricing/index.blade.php
+++ b/resources/views/marketing/pricing/index.blade.php
@@ -81,7 +81,7 @@
 
         <div class="mt-8">
           <a href="#" class="group inline-flex w-full items-center gap-x-2 rounded-sm border border-b-3 border-gray-400 px-3 py-2 transition-colors duration-150 hover:bg-white">
-            <img src="{{ asset('marketing/docker.svg') }}" class="mr-2 inline-block h-8 w-8" />
+            <img src="{{ asset('marketing/docker.svg') }}" class="mr-2 inline-block h-8 w-8" loading="lazy" />
             Download the Docker image
           </a>
         </div>

--- a/resources/views/marketing/why/index.blade.php
+++ b/resources/views/marketing/why/index.blade.php
@@ -30,7 +30,7 @@
           <p>Consider these common scenarios:</p>
 
           <div class="flex items-center gap-x-2">
-            <img src="{{ asset('marketing/sherlock.webp') }}" srcset="{{ asset('marketing/sherlock.webp') }}, {{ asset('marketing/sherlock@2x.webp') }} 2x" height="300" width="200" alt="Sherlock Holmes" class="" />
+            <img src="{{ asset('marketing/sherlock.webp') }}" srcset="{{ asset('marketing/sherlock.webp') }}, {{ asset('marketing/sherlock@2x.webp') }} 2x" height="300" width="200" alt="Sherlock Holmes" class="" loading="lazy" />
             <ul>
               <li>You meet a friend's partner at a dinner party, have a great conversation about their recent trip to Japan, but completely forget these details the next time you meet.</li>
               <li>Your colleague mentions their child's upcoming school play, but you forget to follow up and ask how it went.</li>
@@ -84,7 +84,7 @@
                 <p class="text-primary/50 dark:text-primary-dark/50 m-0 line-clamp-1 text-sm leading-tight">Project maintainer</p>
               </div>
               <div class="flex-shrink-0 px-4 py-2">
-                <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis.webp') }}, {{ asset('marketing/regis@2x.webp') }} 2x" alt="Regis" class="h-12 w-12 rounded-full" />
+                <img src="{{ asset('marketing/regis.webp') }}" srcset="{{ asset('marketing/regis.webp') }}, {{ asset('marketing/regis@2x.webp') }} 2x" alt="Regis" class="h-12 w-12 rounded-full" loading="lazy" />
               </div>
             </a>
           </div>

--- a/resources/views/persons/partials/persons-list.blade.php
+++ b/resources/views/persons/partials/persons-list.blade.php
@@ -31,7 +31,7 @@
       @foreach ($persons as $currentPerson)
         <a href="{{ route('person.show', $currentPerson['slug']) }}" class="{{ isset($person) && $person && $currentPerson['id'] === $person->id ? 'bg-blue-50' : '' }} flex cursor-pointer items-center gap-3 p-3 hover:bg-blue-50">
           <div class="shrink-0">
-            <img class="h-10 w-10 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $currentPerson['avatar']['40'] }}" srcset="{{ $currentPerson['avatar']['40'] }}, {{ $currentPerson['avatar']['80'] }} 2x" alt="{{ $currentPerson['name'] }}" />
+            <img class="h-10 w-10 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $currentPerson['avatar']['40'] }}" srcset="{{ $currentPerson['avatar']['40'] }}, {{ $currentPerson['avatar']['80'] }} 2x" alt="{{ $currentPerson['name'] }}" loading="lazy" />
           </div>
           <div class="min-w-0">
             <p class="truncate font-medium">{{ $currentPerson['name'] }}</p>

--- a/resources/views/persons/partials/profile.blade.php
+++ b/resources/views/persons/partials/profile.blade.php
@@ -10,7 +10,7 @@
     <!-- name + title + age -->
     <div id="profile-header" class="mb-6 flex items-center gap-4">
       <div class="h-16 w-16 shrink-0">
-        <img class="h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $person->getAvatar(64) }}" srcset="{{ $person->getAvatar(64) }}, {{ $person->getAvatar(128) }} 2x" alt="{{ $person->name }}" />
+        <img class="h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $person->getAvatar(64) }}" srcset="{{ $person->getAvatar(64) }}, {{ $person->getAvatar(128) }} 2x" alt="{{ $person->name }}" loading="lazy" />
       </div>
       <div class="flex min-w-0 flex-col gap-1">
         <h1 class="truncate text-xl font-semibold">{{ $person->name }}</h1>

--- a/resources/views/persons/settings/partials/avatar.blade.php
+++ b/resources/views/persons/settings/partials/avatar.blade.php
@@ -38,7 +38,7 @@
       <!-- Front face -->
       <div x-ref="frontFace" class="absolute w-full border border-gray-200 bg-white [backface-visibility:hidden] sm:rounded-lg">
         <div class="grid grid-cols-3 items-center rounded-t-lg p-3 last:rounded-b-lg hover:bg-blue-50">
-          <img width="58" height="58" class="col-span-2 h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $person->getAvatar(64) }}" srcset="{{ $person->getAvatar(64) }}, {{ $person->getAvatar(128) }} 2x" alt="{{ $person->name }}" wire:key="avatar-{{ $person->id }}" />
+          <img width="58" height="58" class="col-span-2 h-16 w-16 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $person->getAvatar(64) }}" srcset="{{ $person->getAvatar(64) }}, {{ $person->getAvatar(128) }} 2x" alt="{{ $person->name }}" loading="lazy" />
           <div class="justify-self-end">
             <x-button.invisible @click="isFlipped = true" class="text-sm">
               {{ __('Upload a new photo') }}


### PR DESCRIPTION
This pull request introduces a performance optimization by adding the `loading="lazy"` attribute to various `<img>` tags across multiple files. This change defers the loading of images until they are about to enter the viewport, improving page load times and resource usage.