### PR TITLE
feat: add food allergy management for children

### DIFF
--- a/app/Http/Controllers/Persons/PersonAllergiesFoodController.php
+++ b/app/Http/Controllers/Persons/PersonAllergiesFoodController.php
@@ -64,6 +64,10 @@ class PersonAllergiesFoodController extends Controller
             foreach ($validated['child_allergies'] as $childId => $allergies) {
                 $targetChild = Child::find($childId);
 
+                if (!$targetChild) {
+                    continue; // Skip invalid child IDs
+                }
+
                 (new UpdateChildFoodAllergy(
                     user: $user,
                     child: $targetChild,

--- a/app/Http/Controllers/Persons/PersonAllergiesFoodController.php
+++ b/app/Http/Controllers/Persons/PersonAllergiesFoodController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Persons;
 
 use App\Http\Controllers\Controller;
+use App\Models\Child;
 use App\Models\Person;
+use App\Services\UpdateChildFoodAllergy;
 use App\Services\UpdatePersonFoodAllergy;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -23,6 +25,9 @@ class PersonAllergiesFoodController extends Controller
         foreach ($person->getActivePartnersAsPersonCollection() as $partner) {
             $personsCollection->push($partner);
         }
+        foreach ($person->children() as $child) {
+            $personsCollection->push($child);
+        }
 
         return view('persons.food.partials.allergies.edit', [
             'person' => $person,
@@ -39,16 +44,29 @@ class PersonAllergiesFoodController extends Controller
         $validated = $request->validate([
             'person_allergies' => 'array',
             'person_allergies.*' => 'nullable|string|max:255',
+            'child_allergies' => 'array',
+            'child_allergies.*' => 'nullable|string|max:255',
         ]);
 
         if (isset($validated['person_allergies']) && is_array($validated['person_allergies'])) {
             foreach ($validated['person_allergies'] as $personId => $allergies) {
-                // Find the person by ID
                 $targetPerson = Person::find($personId);
 
                 (new UpdatePersonFoodAllergy(
                     user: $user,
                     person: $targetPerson,
+                    name: $allergies ?? '',
+                ))->execute();
+            }
+        }
+
+        if (isset($validated['child_allergies']) && is_array($validated['child_allergies'])) {
+            foreach ($validated['child_allergies'] as $childId => $allergies) {
+                $targetChild = Child::find($childId);
+
+                (new UpdateChildFoodAllergy(
+                    user: $user,
+                    child: $targetChild,
                     name: $allergies ?? '',
                 ))->execute();
             }

--- a/app/Models/Child.php
+++ b/app/Models/Child.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
  * @property int|null $second_parent_id
  * @property string $first_name
  * @property string|null $last_name
+ * @property string|null $food_allergies
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
  */
@@ -44,6 +45,7 @@ class Child extends Model
         'second_parent_id',
         'first_name',
         'last_name',
+        'food_allergies',
     ];
 
     /**
@@ -56,6 +58,7 @@ class Child extends Model
         return [
             'first_name' => 'encrypted',
             'last_name' => 'encrypted',
+            'food_allergies' => 'encrypted',
         ];
     }
 

--- a/app/Services/GetFoodListing.php
+++ b/app/Services/GetFoodListing.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Models\Child;
 use App\Models\Person;
 use Illuminate\Support\Collection;
 
@@ -49,6 +50,11 @@ class GetFoodListing
         // remove any entries without allergies
         $uniqueAllergiesCollection = $uniqueAllergiesCollection->filter(fn($item): bool => !empty($item['food_allergies']));
 
+        // get children allergies
+        foreach ($this->person->children() as $child) {
+            $uniqueAllergiesCollection->push($this->childAllergy($child));
+        }
+
         return $uniqueAllergiesCollection->values();
     }
 
@@ -62,6 +68,7 @@ class GetFoodListing
     {
         return [
             'id' => $person->id,
+            'type' => 'person',
             'name' => $person->name,
             'is_listed' => $person->is_listed,
             'slug' => $person->slug,
@@ -70,6 +77,22 @@ class GetFoodListing
                 '80' => $person->getAvatar(80),
             ],
             'food_allergies' => $person->food_allergies,
+        ];
+    }
+
+    /**
+     * Get the allergy data for a child.
+     *
+     * @param Child $child The child to get the allergy data for
+     * @return array The allergy data
+     */
+    public function childAllergy(Child $child): array
+    {
+        return [
+            'id' => $child->id,
+            'type' => 'child',
+            'name' => $child->name,
+            'food_allergies' => $child->food_allergies,
         ];
     }
 }

--- a/app/Services/UpdateChildFoodAllergy.php
+++ b/app/Services/UpdateChildFoodAllergy.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdatePersonLastConsultedDate;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Child;
+use App\Models\Person;
+use App\Models\User;
+use Exception;
+
+class UpdateChildFoodAllergy
+{
+    public function __construct(
+        private readonly User $user,
+        private readonly Child $child,
+        private readonly string $name,
+    ) {}
+
+    public function execute(): Child
+    {
+        $this->validate();
+        $this->create();
+        $this->updatePersonLastConsultedDate();
+        $this->updateUserLastActivityDate();
+        $this->logUserAction();
+
+        return $this->child;
+    }
+
+    private function validate(): void
+    {
+        if ($this->user->account_id !== $this->child->account_id) {
+            throw new Exception('User and child are not in the same account');
+        }
+    }
+
+    private function create(): void
+    {
+        $this->child->food_allergies = $this->name;
+        $this->child->save();
+    }
+
+    private function updatePersonLastConsultedDate(): void
+    {
+        UpdatePersonLastConsultedDate::dispatch($this->child->parent)->onQueue('low');
+    }
+
+    private function updateUserLastActivityDate(): void
+    {
+        UpdateUserLastActivityDate::dispatch($this->user)->onQueue('low');
+    }
+
+    private function logUserAction(): void
+    {
+        LogUserAction::dispatch(
+            user: $this->user,
+            action: 'child_food_allergy_updated',
+            description: 'Updated a food allergy for ' . $this->child->name . ': ' . $this->name,
+        )->onQueue('low');
+    }
+}

--- a/config/peopleos.php
+++ b/config/peopleos.php
@@ -175,5 +175,6 @@ return [
         'child_relationship_deletion' => 'Child relationship deletion',
         'food_allergy_destroyed' => 'Food allergy destroyed',
         'food_allergy_updated' => 'Food allergy update',
+        'child_food_allergy_updated' => 'Child food allergy update',
     ],
 ];

--- a/database/migrations/2025_06_08_143444_add_food_allergies_to_children_table.php
+++ b/database/migrations/2025_06_08_143444_add_food_allergies_to_children_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('children', function (Blueprint $table) {
+            $table->text('food_allergies')->nullable()->after('last_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('children', function (Blueprint $table) {
+            $table->dropColumn('food_allergies');
+        });
+    }
+};

--- a/resources/views/persons/food/partials/allergies/edit.blade.php
+++ b/resources/views/persons/food/partials/allergies/edit.blade.php
@@ -9,21 +9,32 @@
   @csrf
   @method('PUT')
 
-  @foreach ($persons as $person)
+  @foreach ($persons as $human)
+    @if ($human instanceof \App\Models\Child)
+    <div class="items flex items-center justify-between border-b border-gray-200 p-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-gray-50">
+      <p class="truncate text-sm text-gray-900">{{ $human->name }}</p>
+
+      <div>
+        <x-text-input id="child_{{ $human->id }}" name="child_allergies[{{ $human->id }}]" type="text" class="block w-full" placeholder="{{ __('Add allergies') }}" value="{{ $human->food_allergies }}" />
+        <x-input-error :messages="$errors->get('child_allergies.'.$human->id)" class="mt-2" />
+      </div>
+    </div>
+    @else
     <div class="items flex justify-between border-b border-gray-200 p-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-gray-50">
       <div class="flex items-center gap-x-2">
         <div class="shrink-0">
-          <img class="h-6 w-6 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $person->getAvatar(40) }}" srcset="{{ $person->getAvatar(40) }}, {{ $person->getAvatar(40) }} 2x" alt="{{ $person->name }}" loading="lazy" />
+          <img class="h-6 w-6 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $human->getAvatar(40) }}" srcset="{{ $human->getAvatar(40) }}, {{ $human->getAvatar(40) }} 2x" alt="{{ $human->name }}" loading="lazy" />
         </div>
 
-        <p class="truncate text-sm text-gray-900">{{ $person->name }}</p>
+        <p class="truncate text-sm text-gray-900">{{ $human->name }}</p>
       </div>
 
       <div>
-        <x-text-input id="person_{{ $person->id }}" name="person_allergies[{{ $person->id }}]" type="text" class="block w-full" placeholder="{{ __('Add allergies') }}" value="{{ $person->food_allergies }}" />
-        <x-input-error :messages="$errors->get('person_allergies.'.$person->id)" class="mt-2" />
+        <x-text-input id="person_{{ $human->id }}" name="person_allergies[{{ $human->id }}]" type="text" class="block w-full" placeholder="{{ __('Add allergies') }}" value="{{ $human->food_allergies }}" />
+        <x-input-error :messages="$errors->get('person_allergies.'.$human->id)" class="mt-2" />
       </div>
     </div>
+    @endif
   @endforeach
 
   <div class="flex items-center justify-between p-4">

--- a/resources/views/persons/food/partials/allergies/index.blade.php
+++ b/resources/views/persons/food/partials/allergies/index.blade.php
@@ -22,7 +22,8 @@
 
   <div id="food-allergies-listing" class="rounded-lg border border-gray-200 bg-white">
     @forelse ($food_allergies as $allergy)
-      <div class="items flex gap-x-4 border-b border-gray-200 p-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-gray-50">
+      @if ($allergy['type'] === 'person')
+      <div class="items justify-between flex gap-x-4 border-b border-gray-200 p-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-gray-50">
         <div class="flex items-center gap-x-2">
           <div class="shrink-0">
             <img class="h-6 w-6 rounded-full object-cover p-[0.1875rem] shadow-sm ring-1 ring-slate-900/10" src="{{ $allergy['avatar']['40'] }}" srcset="{{ $allergy['avatar']['40'] }}, {{ $allergy['avatar']['80'] }} 2x" alt="{{ $allergy['name'] }}" loading="lazy" />
@@ -36,6 +37,12 @@
         </div>
         <span class="text-normal">{{ $allergy['food_allergies'] }}</span>
       </div>
+      @else
+      <div class="items-center justify-between flex gap-x-4 border-b border-gray-200 p-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 hover:bg-gray-50">
+        <p class="truncate text-sm text-gray-900">{{ $allergy['name'] }}</p>
+        <span class="text-normal">{{ $allergy['food_allergies'] }}</span>
+      </div>
+      @endif
     @empty
       <!-- blank state -->
       <div class="flex flex-col items-center justify-center rounded-lg bg-white p-6 text-center">

--- a/tests/Unit/Services/UpdateChildFoodAllergyTest.php
+++ b/tests/Unit/Services/UpdateChildFoodAllergyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Jobs\LogUserAction;
+use App\Jobs\UpdatePersonLastConsultedDate;
+use App\Jobs\UpdateUserLastActivityDate;
+use App\Models\Child;
+use App\Models\Person;
+use App\Models\User;
+use App\Services\UpdateChildFoodAllergy;
+use App\Services\UpdatePersonFoodAllergy;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class UpdateChildFoodAllergyTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_updates_a_child_food_allergy(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $parent = Person::factory()->create([
+            'account_id' => $user->account_id,
+            'first_name' => 'Ross',
+            'last_name' => 'Geller',
+        ]);
+        $child = Child::factory()->create([
+            'account_id' => $user->account_id,
+            'parent_id' => $parent->id,
+            'second_parent_id' => null,
+            'first_name' => 'Ben',
+            'last_name' => 'Geller',
+        ]);
+
+        $child = (new UpdateChildFoodAllergy(
+            user: $user,
+            child: $child,
+            name: 'Peanuts',
+        ))->execute();
+
+        $this->assertEquals(
+            expected: 'Peanuts',
+            actual: $child->food_allergies,
+        );
+
+        $this->assertInstanceOf(
+            expected: Child::class,
+            actual: $child,
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdateUserLastActivityDate::class,
+            callback: function (UpdateUserLastActivityDate $job) use ($user): bool {
+                return $job->user->id === $user->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: UpdatePersonLastConsultedDate::class,
+            callback: function (UpdatePersonLastConsultedDate $job) use ($parent): bool {
+                return $job->person->id === $parent->id;
+            },
+        );
+
+        Queue::assertPushedOn(
+            queue: 'low',
+            job: LogUserAction::class,
+            callback: function (LogUserAction $job) use ($user, $child): bool {
+                return $job->action === 'child_food_allergy_updated'
+                    && $job->user->id === $user->id
+                    && $job->description === 'Updated a food allergy for Ben Geller: Peanuts';
+            },
+        );
+    }
+
+    #[Test]
+    public function it_throws_an_exception_if_the_user_and_person_are_not_in_the_same_account(): void
+    {
+        $user = User::factory()->create();
+        $child = Child::factory()->create();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User and child are not in the same account');
+
+        (new UpdateChildFoodAllergy(
+            user: $user,
+            child: $child,
+            name: 'Peanuts',
+        ))->execute();
+    }
+}


### PR DESCRIPTION
- Introduced functionality to manage food allergies for children, including validation and updates.
- Updated the UI to allow input of allergies for both persons and children.
- Created a new service, UpdateChildFoodAllergy, to handle the logic for updating a child's food allergies.
- Added migration to include food_allergies field in the children table.
- Enhanced existing services to accommodate child allergy data retrieval.